### PR TITLE
Added description to Dist of OOP and scatterPlot and update css

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,6 +170,11 @@
     </div>
 
     <h2> Distribution of Out-of-Pocket Costs </h2>
+
+    <div>
+        Building on the demographics of Medicare beneficiaries and their supplemental insurance coverage, the bar chart delves into the financial burden faced by beneficiaries in terms of out-of-pocket healthcare costs. The majority of beneficiaries experience relatively low out-of-pocket expenses, with the highest frequency concentrated in the lowest cost category. However, as costs increase, the number of beneficiaries sharply declines, revealing a small but significant group incurring expenses above $10,000. This highlights the uneven distribution of financial responsibility among Medicare beneficiaries, where a vulnerable minority bears disproportionately higher costs.
+    </div>
+
     <div class="row">
         <div id="controls">
             <label for="genderFilter">Gender:</label>
@@ -193,6 +198,15 @@
     </div>
 
     <h2> Relationship between Total Payment and Sum of Out-Of-Pocket Payments</h2>
+    <div>
+        Expanding on the distribution of out-of-pocket expenses, the scatter plot provides additional context by examining the relationship between total healthcare payments and out-of-pocket costs, segmented by income group (<$25,000 and ≥$25,000). While higher total payments often correlate with increased out-of-pocket expenses, the data also uncovers income-based disparities:
+        <ul>
+            <li>Lower-income beneficiaries are concentrated in the lower payment ranges yet still face considerable variability in out-of-pocket costs.</li>
+            <li>Higher-income beneficiaries are more evenly distributed across the payment spectrum, with outliers incurring exceptionally high total payments and out-of-pocket costs.</li>
+        </ul>
+        These patterns underscore the challenges faced by lower-income individuals, who may be disproportionately burdened despite their lower total payments.
+    </div>
+
     <div class="row">
         <div id="scatterPlotControls">
             <label for="incomeFilter">Income Filter:</label>

--- a/js/oopDistribution.js
+++ b/js/oopDistribution.js
@@ -81,6 +81,15 @@ class OOPDistributionVis {
     updateVis() {
         const vis = this;
 
+        // Get selected gender to determine bar color
+        const selectedGender = d3.select("#genderFilter").property("value");
+        let barColor = "#FAC748"; // Default color
+        if (selectedGender === "female") {
+            barColor = "#F7ACCF";
+        } else if (selectedGender === "male") {
+            barColor = "#99B2DD";
+        }
+
         // Generate histogram data
         const bins = d3.bin()
             .value(d => +d.PAMTOOP)
@@ -100,13 +109,15 @@ class OOPDistributionVis {
             .attr("y", vis.height) // Start at the bottom of the chart
             .attr("width", d => vis.xScale(d.x1) - vis.xScale(d.x0) - 1)
             .attr("height", 0) // Start with zero height
-            .style("fill", "#69b3a2")
+            .style("fill", barColor)
             .on("mouseover", (event, d) => {
                 vis.tooltip.transition().duration(200).style("opacity", 1);
                 vis.tooltip.html(`
-                    <strong>Range:</strong> ${d.x0.toFixed(2)} - ${d.x1.toFixed(2)}<br>
-                    <strong>Frequency:</strong> ${d.length}
-                `)
+            <div style="border: 1px solid black; border-radius: 5px; background: white; padding: 10px; font-size: 14px; font-family: sans-serif; box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);">
+                <strong>Range:</strong> ${d.x0.toFixed(2)} - ${d.x1.toFixed(2)}<br>
+                <strong>Frequency:</strong> ${d.length}
+            </div>
+        `)
                     .style("left", (event.pageX + 10) + "px")
                     .style("top", (event.pageY - 20) + "px");
             })
@@ -123,7 +134,8 @@ class OOPDistributionVis {
             .attr("x", d => vis.xScale(d.x0))
             .attr("y", d => vis.yScale(d.length))
             .attr("width", d => vis.xScale(d.x1) - vis.xScale(d.x0) - 1)
-            .attr("height", d => vis.height - vis.yScale(d.length));
+            .attr("height", d => vis.height - vis.yScale(d.length))
+            .style("fill", barColor);
 
         // EXIT
         bars.exit()

--- a/js/oopScatter.js
+++ b/js/oopScatter.js
@@ -61,7 +61,7 @@ class OOPScatterVis {
         // Define legend scale
         vis.legendColorScale = d3.scaleOrdinal()
             .domain(["< $25,000", ">= $25,000"])
-            .range(["#1f77b4", "#ff7f0e"]);
+            .range(["#FAC748", "#9FD356"]);
 
         // Tooltip
         vis.tooltip = d3.select("body").append("div")
@@ -105,7 +105,7 @@ class OOPScatterVis {
             .attr("cx", d => vis.xScale(+d.PAMTTOT))
             .attr("cy", vis.height) // Start at the bottom
             .attr("r", 4)
-            .style("fill", d => d.CSP_INCOME === 1 ? "#1f77b4" : "#ff7f0e") // Color by income
+            .style("fill", d => d.CSP_INCOME === 1 ? "#FAC748" : "#9FD356") // Color by income
             .style("opacity", 0.7)
             .on("mouseover", (event, d) => {
                 vis.tooltip.transition().duration(200).style("opacity", 1);


### PR DESCRIPTION
_**What is updated?**_ 
- Added description to Distribution of Out-of-Pocket Costs bar chart. 
- Added description to Relationship between Total Payment and Sum of Out-Of-Pocket Payments scatter plot
- Updated the bar chart that whenever the gender filter changed, the bar chart color changes to pink/blue. 
- **[Consistency purpose]** Updated to tooltip of bar chart to match demographic map
- **[Consistency purpose]** Updated the color of scatter plot to yellow and green to match the color used in demographic map.

_**What is not changed?**_
- The tooltip of scatterplot. The tooltip used in demographic maps and bar chart has no transparency, so it may block other datapoints in the scatter plot due to the density of the points.